### PR TITLE
- project name/desc <div> now same height as project image.

### DIFF
--- a/src/app/dashboard/dashboard.component.scss
+++ b/src/app/dashboard/dashboard.component.scss
@@ -50,6 +50,7 @@ a :hover {
   position: relative;
   text-align: left;
   width: 945px;
+  height: 50px;
   margin: 0 105px;
 }
 


### PR DESCRIPTION
this fixes the suites/test info alignment problem.
